### PR TITLE
Upgrade to Leaflet 1.0.2 and upgrade plug-ins. Close #34

### DIFF
--- a/index.html
+++ b/index.html
@@ -34,15 +34,15 @@
 	<meta property="og:site_name" content="Fairphone Community Map">
 
 	<!-- Styles -->
-	<link rel="stylesheet" href="https://bowercdn.net/c/leaflet-0.7.7/dist/leaflet.css" integrity="sha384-E9vFwWyHrMFVHKrPgvBjKuVepLDtu+A/vJWwKWrQJ4nZEGbuwutpoM6VNO/nc9dm" crossorigin="anonymous">
-	<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/leaflet.markercluster/0.5.0/MarkerCluster.Default.css" integrity="sha384-5kMSQJ6S4Qj5i09mtMNrWpSi8iXw230pKU76xTmrpezGnNJQzj0NzXjQLLg+jE7k" crossorigin="anonymous">
-	<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/leaflet.markercluster/0.5.0/MarkerCluster.css" integrity="sha384-lPzjPsFQL6te2x+VxmV6q1DpRxpRk0tmnl2cpwAO5y04ESyc752tnEWPKDfl1olr" crossorigin="anonymous">
+	<link rel="stylesheet" href="https://bowercdn.net/c/leaflet-1.0.2/dist/leaflet.css" integrity="sha384-guwBzjUFEc1B92ajTRfHEdACdBUYkADKEV5GOLu4xKAjtkICPQbBVazxdxLgwxSR" crossorigin="anonymous">
+	<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/leaflet.markercluster/1.0.0/MarkerCluster.Default.css" integrity="sha384-5kMSQJ6S4Qj5i09mtMNrWpSi8iXw230pKU76xTmrpezGnNJQzj0NzXjQLLg+jE7k" crossorigin="anonymous">
+	<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/leaflet.markercluster/1.0.0/MarkerCluster.css" integrity="sha384-lPzjPsFQL6te2x+VxmV6q1DpRxpRk0tmnl2cpwAO5y04ESyc752tnEWPKDfl1olr" crossorigin="anonymous">
 	<link rel="stylesheet" href="css/style.css">
 
 	<!-- JavaScript dependencies -->
-	<script src="https://bowercdn.net/c/leaflet-0.7.7/dist/leaflet.js" integrity="sha384-4Ifnoz9LNf2sA2ORMPewbkMQu5OokK+aIUxSHRgpkAuZTogV7y974DdOKyy6GaaY" crossorigin="anonymous"></script>
-	<script src="https://cdnjs.cloudflare.com/ajax/libs/leaflet.markercluster/0.5.0/leaflet.markercluster-src.js" integrity="sha384-DWfQP+GCYps97g3yfrDI8mUTMqyjWK8RLB3hHEq8i9j5orKVzJaeXTGl/skeKsiP" crossorigin="anonymous"></script>
-	<script src="https://cdn.rawgit.com/ghybs/Leaflet.FeatureGroup.SubGroup/v0.1.1/leaflet.featuregroup.subgroup.js" integrity="sha384-yMCVKGLbAWnD74B6nP4lap39OuYgIcIvmPSG4rtvFZBfJMRw9E02CCglSI10CIJM" crossorigin="anonymous"></script>
+	<script src="https://bowercdn.net/c/leaflet-1.0.2/dist/leaflet.js" integrity="sha384-7a9MgcSjn3RMDo2uU4dqaWXWZKWu98fqa+SinDtC4nahnxJzAbiLfRYwzVsfLsD8" crossorigin="anonymous"></script>
+	<script src="https://cdnjs.cloudflare.com/ajax/libs/leaflet.markercluster/1.0.0/leaflet.markercluster-src.js" integrity="sha384-ho4yZuhivic8f9ODd7mDXL0tnARAH7Kjrvuziv1WljsEU8HMV416zSDtLTdMyz8i" crossorigin="anonymous"></script>
+	<script src="https://unpkg.com/leaflet.featuregroup.subgroup@1.0.1/dist/leaflet.featuregroup.subgroup.js" integrity="sha384-7HPjqMPRm3CuFKmep86m24tncYkpJU3l+R4MVcve3PMsLW9mlaXxfBIDmriWsv8V" crossorigin="anonymous"></script>
 
 	<!-- JavaScript polyfills -->
 	<script src="https://bowercdn.net/c/es6-promise-3.2.2/es6-promise.min.js" integrity="sha384-GF7IR8yT5028AbfHnSJSxX0Y1D+sicFNHXDyV1Hzcf4EISXdjP8uW0Q/0yFIHpTD" crossorigin="anonymous"></script>


### PR DESCRIPTION
Seems that Leaflet and plug-ins all are using unpkg.com now.
I kept the CDNs we were using before except for rawgit, which didn't
have the latest release of the subgroup.js plug-in.

Tested on Firefox 50.1.0