### PR TITLE
Collapse layer controls on map move start. Close #27

### DIFF
--- a/js/main.js
+++ b/js/main.js
@@ -38,6 +38,7 @@
 
   /* Variables (state) */
   var map;
+  var layerControls;
   var cluster = L.markerClusterGroup();
   var overlaysData = {
     angels: {
@@ -95,9 +96,10 @@
   }
 
   function initControls() {
-    L.control.layers(null, getAllOverlays(overlaysData), {
+    layerControls = L.control.layers(null, getAllOverlays(overlaysData), {
       collapsed: false,
-    }).addTo(map);
+    });
+    layerControls.addTo(map);
   }
 
   function getDefaultOverlays() {
@@ -107,10 +109,19 @@
     return overlays.split(',');
   }
 
+  function onMovestart(e) {
+    if(!layerControls.collapsed) {
+        layerControls.collapse();
+      }
+  }
+
   /* Main */
   var defaultOverlays = getDefaultOverlays();
   initMap(defaultOverlays);
   initControls();
+
+  // Add listeners
+  map.on('movestart', onMovestart);
 
   // Populate Fairphoners Groups overlay
   fetchJSON('data/communities.json')


### PR DESCRIPTION
This should free more of the map view on small screens.

This commit is dependent on PR #36 because it makes use of the `collapse()` function introduced in Leaflet 1.