### PR TITLE
Add absolute paths for scripts

### DIFF
--- a/scripts/fetch-angels.py
+++ b/scripts/fetch-angels.py
@@ -3,5 +3,5 @@ import json, os.path, requests, yaml
 response = requests.get('https://forum.fairphone.com/raw/48676/1')
 
 if response.status_code == requests.codes.ok :
-    with open(os.path.dirname(__file__) + "/../data/angels.json","w") as file:
+    with open(os.path.dirname(os.path.abspath(__file__)) + "/../data/angels.json","w") as file:
         json.dump(yaml.safe_load(response.text), file, indent=2)

--- a/scripts/fetch-events.py
+++ b/scripts/fetch-events.py
@@ -3,5 +3,5 @@ import json, os.path, requests
 response = requests.get('https://forum.fairphone.com/agenda.json')
 
 if response.status_code == requests.codes.ok :
-    with open(os.path.dirname(__file__) + "/../data/events.json","w") as file:
+    with open(os.path.dirname(os.path.abspath(__file__)) + "/../data/events.json","w") as file:
         json.dump(response.json()['topic_list']['topics'], file, indent=2)


### PR DESCRIPTION
Add absolute paths for scripts when downloading data files, so the
scripts can be run manually from anywhere.