### PR TITLE
Stop on data failure

### DIFF
--- a/.github/workflows/build_and_deploy.yml
+++ b/.github/workflows/build_and_deploy.yml
@@ -34,7 +34,16 @@ jobs:
           python scripts/fetch-angels.py
           python scripts/fetch-events.py
 
-      - name: Deploy
+      - name: Check for changes in data files when scheduled
+        id: check_for_changes
+        if: ${{ github.event_name == 'schedule' }}
+        run: |
+          git add data # git diff does not work on unversioned files
+          git diff --quiet --exit-code gh-pages -- data
+          echo "::set-output name=has_changes::$?"
+
+      - name: Deploy on push or if scheduled and has changes
+        if: ${{ github.event_name != 'schedule' || steps.check_for_changes.outputs.has_changes }}
         uses: JamesIves/github-pages-deploy-action@4.1.4
         with:
           branch: gh-pages # The branch the action should deploy to.

--- a/.github/workflows/build_and_deploy.yml
+++ b/.github/workflows/build_and_deploy.yml
@@ -5,6 +5,7 @@ on:
       - master
   schedule:
     - cron: '17 * * * *'  # every hour at 17 mins (to avoid spikes e.g. at the beginning of each hour)
+  workflow_dispatch:
 
 jobs:
   build-and-deploy:

--- a/scripts/fetch-angels.py
+++ b/scripts/fetch-angels.py
@@ -1,7 +1,9 @@
-import json, os.path, requests, yaml
+import json, os.path, requests, sys, yaml
 
 response = requests.get('https://forum.fairphone.com/raw/48676/1')
 
 if response.status_code == requests.codes.ok :
     with open(os.path.dirname(os.path.abspath(__file__)) + "/../data/angels.json","w") as file:
         json.dump(yaml.safe_load(response.text), file, indent=2)
+else :
+    sys.exit(1)

--- a/scripts/fetch-events.py
+++ b/scripts/fetch-events.py
@@ -1,7 +1,9 @@
-import json, os.path, requests
+import json, os.path, requests, sys
 
 response = requests.get('https://forum.fairphone.com/agenda.json')
 
 if response.status_code == requests.codes.ok :
     with open(os.path.dirname(os.path.abspath(__file__)) + "/../data/events.json","w") as file:
         json.dump(response.json()['topic_list']['topics'], file, indent=2)
+else :
+    sys.exit(1)


### PR DESCRIPTION
Python scripts now set an error code when they can't fetch the data from the forum.

In addition, if the run was scheduled and the data hasn't changed, don't execute the deploy action.

And finally add a workflow trigger to run the build and deploy manually